### PR TITLE
small bugfixes

### DIFF
--- a/app/Models/Author.php
+++ b/app/Models/Author.php
@@ -39,7 +39,7 @@ class Author extends Model implements HasMediaCollections, HasMediaConversions
             return mb_strtoupper(mb_substr($nameArray[0], 0, 1)) . mb_strtoupper(mb_substr($nameArray[1], 0, 1));
         }
 
-        return mb_strtoupper($this->title, 0, 2);
+        return mb_strtoupper($this->title);
     }
 
     public function getFullNameAttribute(): string

--- a/app/Models/Author.php
+++ b/app/Models/Author.php
@@ -39,7 +39,7 @@ class Author extends Model implements HasMediaCollections, HasMediaConversions
             return mb_strtoupper(mb_substr($nameArray[0], 0, 1)) . mb_strtoupper(mb_substr($nameArray[1], 0, 1));
         }
 
-        return mb_strtoupper($this->title);
+        return mb_substr($this->title, 0, 2);
     }
 
     public function getFullNameAttribute(): string

--- a/database/migrations/2019_06_13_084424_add_author_id_to_posts_table.php
+++ b/database/migrations/2019_06_13_084424_add_author_id_to_posts_table.php
@@ -14,7 +14,7 @@ class AddAuthorIdToPostsTable extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->integer('author_id')->nullable();
+            $table->unsignedInteger('author_id')->nullable();
             $table->foreign('author_id')->references('id')->on('authors')->onDelete('cascade');
         });
     }

--- a/database/migrations/2019_07_17_145958_create_articles_with_relationships_table.php
+++ b/database/migrations/2019_07_17_145958_create_articles_with_relationships_table.php
@@ -19,7 +19,7 @@ class CreateArticlesWithRelationshipsTable extends Migration
             $table->text('perex')->nullable();
             $table->date('published_at')->nullable();
             $table->boolean('enabled')->default(false);
-            $table->integer('author_id')->nullable();
+            $table->unsignedInteger('author_id')->nullable();
             $table->foreign('author_id')->references('id')->on('authors')->onDelete('cascade');
             $table->timestamps();
         });

--- a/database/migrations/2020_07_09_080738_create_articles_with_relationship_tag_table.php
+++ b/database/migrations/2020_07_09_080738_create_articles_with_relationship_tag_table.php
@@ -15,7 +15,7 @@ class CreateArticlesWithRelationShipTagTable extends Migration
     {
         Schema::create('articles_with_relationship_tag', function (Blueprint $table) {
             $table->unsignedInteger('articles_with_relationship_id');
-            $table->foreign('articles_with_relationship_id')
+            $table->foreign('articles_with_relationship_id', 'foreign_key_name')
                 ->references('id')
                 ->on('articles_with_relationships')
                 ->onDelete('cascade');


### PR DESCRIPTION
Fixes migration errors on mysql
General error: 1215 Cannot add foreign key constraint
Syntax error or access violation: 1059 Identifier name '....' is too long
and
mb_strtoupper() expects at most 2 parameters, 3 given
